### PR TITLE
Update Compat Entry for FunSQL

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,6 @@ PrettyPrinting = "54e16d92-306c-5ea0-a30b-337be88ac337"
 
 [compat]
 julia = "1.6"
-FunSQL = "0.11"
+FunSQL = "0.12, 0.13"
 PrettyPrinting = "0.3.2, 0.4"
 JSON = "0.21"


### PR DESCRIPTION
Can we bump the latest version of the FunSQL dependency? I want to update some of my packages that use this for testing and it is restricting some of my packages.